### PR TITLE
feat: Component render path is no longer included in data loader props

### DIFF
--- a/src/DataLoading.ts
+++ b/src/DataLoading.ts
@@ -3,7 +3,7 @@ import { LayoutApi } from 'json-react-layouts'
 export type LoadData<DataLoadArguments extends object, TData, Services extends object> = (
     dataDefinitionArgs: DataLoadArguments,
     services: Services,
-    context: { componentRenderPath: string; resourceType: string; paramsCacheKey: string },
+    context: { resourceType: string; paramsCacheKey: string },
 ) => Promise<TData>
 
 export interface DataDefinition<
@@ -26,7 +26,6 @@ export interface ComponentState<TData> {
 }
 
 export interface LoadArguments<Services extends object> {
-    componentRenderPath: string
     dataDefinition: DataDefinition<any, any, Services>
     dataDefinitionArgs: any
     layout: LayoutApi<any, any, Services, any, any>

--- a/src/data-loading.test.tsx
+++ b/src/data-loading.test.tsx
@@ -132,8 +132,7 @@ it('cap wrap data load function', async () => {
     expect(wrapArgs).toEqual({ dataArg: 'Foo' })
     expect(wrapServices).toEqual({ serviceProp: 'example' })
     expect(wrapContext).toEqual({
-        componentRenderPath: '[0-test-composition]/main[0]',
-        paramsCacheKey: 'dba86410',
+        paramsCacheKey: '7c4bd5d4',
         resourceType: 'component-data-loader',
     })
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,7 +50,6 @@ export function init<Services extends object>(
         'component-data-loader',
         ({
             dataDefinitionArgs,
-            componentRenderPath,
             dataDefinition,
             layout,
             resourceType,
@@ -60,12 +59,11 @@ export function init<Services extends object>(
             const loadFn = wrapLoad ? wrapLoad(dataDefinition.loadData) : dataDefinition.loadData
 
             return loadFn(dataDefinitionArgs, services as any, {
-                componentRenderPath,
                 resourceType,
                 paramsCacheKey,
             })
         },
-        ['componentRenderPath', 'dataDefinitionArgs'],
+        ['dataDefinitionArgs'],
     )
 
     return {
@@ -139,7 +137,6 @@ export function init<Services extends object>(
                 return (
                     <ComponentDataLoader
                         layout={services.layout}
-                        componentRenderPath={componentProps.componentRenderPath}
                         dataDefinition={dataDefinition}
                         dataDefinitionArgs={dataDefinitionArgs}
                         renderData={renderProps => {


### PR DESCRIPTION
This allows data to be shared amongst different components based on the data, not where the data is in the page